### PR TITLE
Fix: Ensure data loads into video and subscriber tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -337,27 +337,7 @@
         }
         window.addEventListener('scroll', handleScroll);
 
-        // Fetch comments data
-        fetch('users_comment.json')
-            .then(response => {
-                if (!response.ok) {
-                    throw new Error('Network response was not ok ' + response.statusText);
-                }
-                return response.json();
-            })
-            .then(data => {
-                commentsData = data;
-                // Initial load for videos should happen after comments are fetched
-                loadItems('video', videoItemsToShow); 
-            })
-            .catch(error => {
-                console.error('There has been a problem with your fetch operation for comments:', error);
-                // Still load videos even if comments fail
-                loadItems('video', videoItemsToShow);
-            });
-
-        loadItems('subscriber', subscriberItemsToShow);
-        updateSubscriberCountHeader();
+        loadAllData(); // Ensure all data is loaded on page load
     </script>
 
 </body></html>


### PR DESCRIPTION
The `loadAllData()` function, responsible for fetching and displaying video, subscriber, and comment data, was defined but not called on page load. This resulted in empty video and subscriber tabs.

This commit fixes the issue by:
1. Calling `loadAllData()` at the end of the main script in `index.html`.
2. Removing a redundant, partial data loading mechanism that fetched only comments and attempted to load videos separately.
3. Removing redundant calls to `loadItems` and `updateSubscriberCountHeader` that are now handled within `loadAllData`.

With these changes, all JSON data is fetched upon page load, and the "영상" (video) and "구독자" (subscriber) tabs are populated as intended.